### PR TITLE
Prevent deadlock when background threads fail to start, add non-RT fallback

### DIFF
--- a/src/zeta-convolver.h
+++ b/src/zeta-convolver.h
@@ -266,7 +266,7 @@ private:
 	            float**  inpbuff,
 	            float**  outbuff);
 
-	void start (int absprio, int policy, double period_ns);
+	bool start (int absprio, int policy, double period_ns);
 
 	void process ();
 


### PR DESCRIPTION
On systems where RT priorities are not enabled, zconvo was leading to deadlocks due to waiting forever for a thread that did not start.
It is not optimal, but we can as last resort try to start the background threads without RT/sched info, which makes the plugin usable on more systems.
